### PR TITLE
refactor: use async fs operations

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const path = require('path');
-const fs = require('fs');
+// Use the promise-based fs API to avoid blocking the event loop with
+// synchronous file system calls.
+const fs = require('fs').promises;
 
 const app = express();
 const PORT = process.env.PORT || 5000;
@@ -11,38 +13,64 @@ app.use('/images', express.static(path.join(__dirname, 'public/images')));
 app.use(express.static(path.join(__dirname, '../build'))); // For serving React build
 
 // Load lesson files dynamically
-app.get('/api/:langCode/lessons.json', (req, res) => {
+app.get('/api/:langCode/lessons.json', async (req, res) => {
   const langCode = req.params.langCode; // Extract the language code
-  const lessonsFilePath = path.join(__dirname, `data/${langCode}/lessons.json`);
-  
-  if (fs.existsSync(lessonsFilePath)) {
-    const lessons = JSON.parse(fs.readFileSync(lessonsFilePath, 'utf8'));
+  const lessonsFilePath = path.join(
+    __dirname,
+    `data/${langCode}/lessons.json`
+  );
+
+  try {
+    const fileData = await fs.readFile(lessonsFilePath, 'utf8');
+    const lessons = JSON.parse(fileData);
     res.json(lessons);
-  } else {
-    res.status(404).send({ error: 'Lessons file not found for this language' });
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      res
+        .status(404)
+        .send({ error: 'Lessons file not found for this language' });
+    } else {
+      res.status(500).send({ error: 'Failed to load lessons file' });
+    }
   }
 });
 
-app.get('/api/:langCode/:lessonFile', (req, res) => {
+app.get('/api/:langCode/:lessonFile', async (req, res) => {
   const { langCode, lessonFile } = req.params;
-  const lessonFilePath = path.join(__dirname, `data/${langCode}/${lessonFile}`);
+  const lessonFilePath = path.join(
+    __dirname,
+    `data/${langCode}/${lessonFile}`
+  );
 
-  if (fs.existsSync(lessonFilePath)) {
-    const lesson = JSON.parse(fs.readFileSync(lessonFilePath, 'utf8'));
+  try {
+    const fileData = await fs.readFile(lessonFilePath, 'utf8');
+    const lesson = JSON.parse(fileData);
     res.json(lesson);
-  } else {
-    res.status(404).send({ error: 'Lesson file not found for this language' });
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      res.status(404).send({ error: 'Lesson file not found for this language' });
+    } else {
+      res.status(500).send({ error: 'Failed to load lesson file' });
+    }
   }
 });
 
-app.get('/server/data/languages.json', (req, res) => {
-  const languagesFilePath = path.join(__dirname, 'data/languages.json'); // Path to your languages.json file
-  
-  if (fs.existsSync(languagesFilePath)) {
-    const languages = JSON.parse(fs.readFileSync(languagesFilePath, 'utf8'));
+app.get('/server/data/languages.json', async (req, res) => {
+  const languagesFilePath = path.join(
+    __dirname,
+    'data/languages.json'
+  ); // Path to your languages.json file
+
+  try {
+    const fileData = await fs.readFile(languagesFilePath, 'utf8');
+    const languages = JSON.parse(fileData);
     res.json(languages);
-  } else {
-    res.status(404).send({ error: 'Languages file not found' });
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      res.status(404).send({ error: 'Languages file not found' });
+    } else {
+      res.status(500).send({ error: 'Failed to load languages file' });
+    }
   }
 });
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+// The default test created by Create React App looked for a "learn react" link,
+// but our application renders a loading state while data is fetched. Update the
+// test to reflect the current behaviour of the App component.
+test('renders initial loading state', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const loadingElement = screen.getByText(/Loading.../i);
+  expect(loadingElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- avoid blocking event loop by switching to asynchronous file reads on API routes
- adjust default App test to check for loading state

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689cac4e2ad08327b675162009b700f6